### PR TITLE
feat: update crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,9 @@ members = ["flips-sys"]
 
 [package]
 name = "flips"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Martin Larralde <martin.larralde@ens-paris-saclay.fr>"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0"
 description = "Rust bindings to Flips, the Floating IPS patcher."
 repository = "https://github.com/althonos/flips.rs"
@@ -23,13 +23,9 @@ repository = "althonos/flips.rs"
 [badges.maintenance]
 status     = "actively-developed"
 
-[dependencies.flips-sys]
-path = "./flips-sys"
-version = "0.2.1"
-default-features = false
-[dependencies.err-derive]
-version = "0.2.3"
-optional = true
+[dependencies]
+flips-sys = { path = "./flips-sys", version = "0.2.2", default-features = false }
+err-derive = { version = "0.3.1", optional = true }
 
 [features]
 default = ["std"]

--- a/flips-sys/Cargo.toml
+++ b/flips-sys/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "flips-sys"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Martin Larralde <martin.larralde@ens-paris-saclay.fr>"]
-edition = "2018"
+edition = "2021"
 build = "build.rs"
 license = "GPL-3.0"
 description = "Raw FFI bindings to Flips, the Floating IPS patcher."
@@ -31,18 +31,16 @@ repository = "althonos/flips.rs"
 [badges.maintenance]
 status     = "actively-developed"
 
-[dependencies.libc]
-version = "0.2.68"
-[dependencies.crc32fast]
-version = "1.2.0"
-default-features = false
+[dependencies]
+libc = "0.2.140"
+crc32fast = { version = "1.3.2", default-features = false }
 
 [build-dependencies]
 cc = "1.0"
 
 [dev-dependencies]
-quickcheck = "0.9"
-quickcheck_macros = "0.9"
+quickcheck = "1.0.3"
+quickcheck_macros = "1.0.0"
 
 [features]
 std = ["crc32fast/std"]

--- a/flips-sys/build.rs
+++ b/flips-sys/build.rs
@@ -8,7 +8,7 @@ fn main() {
     let ref flips = cwd.join("flips");
     let ref patched = std::path::PathBuf::from(out).join("flips");
 
-    // copy C++ sources refering to `crc32.h` locally to a different folder
+    // copy C++ sources referring to `crc32.h` locally to a different folder
     // to force them to use the one we defined in `src`.
     std::fs::create_dir_all(patched).ok();
     for name in &["libups.cpp", "libbps.cpp", "libbps-suf.cpp"] {

--- a/flips-sys/src/test_utils.rs
+++ b/flips-sys/src/test_utils.rs
@@ -49,7 +49,7 @@ impl PartialEq for ArbitraryBuffer {
 }
 
 impl quickcheck::Arbitrary for ArbitraryBuffer {
-    fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
         let mut buffer = Self::default();
         for i in 0..buffer.buffer[..].len() {
             buffer.buffer[i] = u8::arbitrary(g);

--- a/src/bps.rs
+++ b/src/bps.rs
@@ -53,6 +53,7 @@ impl<B: AsRef<[u8]>> AsRef<[u8]> for BpsPatch<B> {
 
 /// The output created by the application of a BPS patch.
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct BpsOutput {
     mem: FlipsMemory,
     metadata: Option<FlipsMemory>,


### PR DESCRIPTION
In this PR:
* Updated the packages edition to 2021
* Updated the packages version to 0.2.2 (as there is be no API changes)
* Updated the crates to their latest versions
* Fixed a compilation error in flips-sys/src/test_utils.rs
* Fixed a warning in src/bps.rs
* Fixed a typo in flips-sys/build.rs